### PR TITLE
Various bug fixs and enhancements on TeX math rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 /*jslint node: true */
 'use strict';
 
+const replaceNl = require('./md-html-util').replaceNl;
+
 const escapeHtml = require('./md-html-util').escapeHtml
 
 const unescapeMd = require('./md-html-util').unescapeMd;
@@ -153,11 +155,11 @@ module.exports = function math_plugin(md, options) {
     options = options || {};
 
     var inlineRenderer = function(tokens, idx){
-        return '<img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURIComponent(tokens[idx].content) + '" alt="' + escapeHtml(tokens[idx].content).trim() + '"/>'
+        return '<img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURIComponent(tokens[idx].content) + '" alt="' + escapeHtml(replaceNl(tokens[idx].content)).trim() + '"/>'
     };
 
     var blockRenderer = function(tokens, idx){
-        return '<p><img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURIComponent(tokens[idx].content) + '" alt="' + escapeHtml(tokens[idx].content).trim() + '"/></p>'
+        return '<p><img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURIComponent(tokens[idx].content) + '" alt="' + escapeHtml(replaceNl(tokens[idx].content)).trim() + '"/></p>'
     }
 
     var imageRenderer = function(tokens, idx) {

--- a/index.js
+++ b/index.js
@@ -155,11 +155,13 @@ module.exports = function math_plugin(md, options) {
     options = options || {};
 
     var inlineRenderer = function(tokens, idx){
-        return '<img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURIComponent(tokens[idx].content) + '" alt="' + escapeHtml(replaceNl(tokens[idx].content)).trim() + '"/>'
+        return '<img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURIComponent(tokens[idx].content)
+             + '" alt="' + escapeHtml(replaceNl(tokens[idx].content)).trim() + '"/>'
     };
 
     var blockRenderer = function(tokens, idx){
-        return '<p><img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURIComponent(tokens[idx].content) + '" alt="' + escapeHtml(replaceNl(tokens[idx].content)).trim() + '"/></p>'
+        return '<p><img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURIComponent('\\displaystyle ' + tokens[idx].content)
+             + '" alt="' + escapeHtml(replaceNl('\\displaystyle ' + tokens[idx].content)).trim() + '"/></p>'
     }
 
     var imageRenderer = function(tokens, idx) {

--- a/index.js
+++ b/index.js
@@ -153,11 +153,11 @@ module.exports = function math_plugin(md, options) {
     options = options || {};
 
     var inlineRenderer = function(tokens, idx){
-        return '<img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURI(tokens[idx].content) + '" alt="' + escapeHtml(tokens[idx].content).trim() + '"/>'
+        return '<img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURIComponent(tokens[idx].content) + '" alt="' + escapeHtml(tokens[idx].content).trim() + '"/>'
     };
 
     var blockRenderer = function(tokens, idx){
-        return '<p><img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURI(tokens[idx].content) + '" alt="' + escapeHtml(tokens[idx].content).trim() + '"/></p>'
+        return '<p><img eeimg="1" src="//www.zhihu.com/equation?tex=' + encodeURIComponent(tokens[idx].content) + '" alt="' + escapeHtml(tokens[idx].content).trim() + '"/></p>'
     }
 
     var imageRenderer = function(tokens, idx) {

--- a/md-html-util.js
+++ b/md-html-util.js
@@ -13,6 +13,10 @@ function replaceUnsafeChar(ch) {
 	return HTML_REPLACEMENTS[ch];
 }
 
+function replaceNl(str) {
+	return str.replace(/[\n]/g," ");
+}
+
 function escapeHtml(str) {
 	if (HTML_ESCAPE_TEST_RE.test(str)) {
 		return str.replace(HTML_ESCAPE_REPLACE_RE, replaceUnsafeChar);
@@ -49,7 +53,7 @@ function beautifyDate(date) {
 }
 
 
-
+exports.replaceNl = replaceNl;
 exports.escapeHtml =  escapeHtml;
 exports.unescapeMd = unescapeMd;
 exports.removeHtmlTag = removeHtmlTag;


### PR DESCRIPTION
The followings are various bug fixs (2) and enhancement (1) on TeX math rendering. This is a part of work in an attempt to resolve niudai/VSCode-Zhihu#171. See each comment below for details.

`encodeURI()` in Javascript does not escape `; / ? : @ & = + $ , #`, while these characters may exist in a TeX math. Among them `&` is frequently used, for example in a `aligned` environment.

However, when appending `encodeURI(tokens[idx].content)` to the URL `//www.zhihu.com/equation?tex=`, `&` is interpreted as an argument separator. This causes the resulting URL not desired (though seemingly harmless in [Zhihu On VSCode](https://github.com/niudai/VSCode-Zhihu)). `encodeURIComponent()` is a better choice as it escapes more characters including `$`.